### PR TITLE
Mission editing slang (#502)

### DIFF
--- a/src/components/assessment/assessmentShape.ts
+++ b/src/components/assessment/assessmentShape.ts
@@ -16,6 +16,7 @@ export interface IAssessmentOverview {
   maxXp: number;
   openAt: string;
   title: string;
+  reading?: string;
   shortSummary: string;
   status: AssessmentStatus;
   story: string | null;

--- a/src/components/incubator/assessmentTemplates.ts
+++ b/src/components/incubator/assessmentTemplates.ts
@@ -41,6 +41,7 @@ export const overviewTemplate = (): IAssessmentOverview => {
     maxXp: 0,
     openAt: '2000-01-01T00:00+08',
     title: 'Insert title here',
+    reading: '',
     shortSummary: 'Insert short summary here',
     status: AssessmentStatuses.not_attempted,
     story: 'mission',
@@ -51,7 +52,7 @@ export const overviewTemplate = (): IAssessmentOverview => {
 
 export const programmingTemplate = (): IProgrammingQuestion => {
   return {
-    answer: '//1st question mock solution template',
+    answer: '// [Marking Scheme]\n// 1 mark for correct answer',
     comment: '`Great Job` **young padawan**',
     content: 'Enter content here',
     id: 0,

--- a/src/components/incubator/editingWorkspaceSideContent/MCQQuestionTemplateTab.tsx
+++ b/src/components/incubator/editingWorkspaceSideContent/MCQQuestionTemplateTab.tsx
@@ -1,11 +1,10 @@
 import { Card } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
-import AceEditor from 'react-ace';
 
 import { IAssessment, IMCQQuestion } from '../../assessment/assessmentShape';
 import { controlButton } from '../../commons';
-import { assignToPath, getValueFromPath, limitNumberRange } from './';
+import { limitNumberRange } from './';
 import TextareaContent from './TextareaContent';
 
 interface IProps {
@@ -14,90 +13,14 @@ interface IProps {
   updateAssessment: (assessment: IAssessment) => void;
 }
 
-interface IState {
-  templateValue: string;
-  templateFocused: boolean;
-}
-
-export class QuestionTemplateTab extends React.Component<IProps, IState> {
+export class MCQQuestionTemplateTab extends React.Component<IProps, {}> {
   public constructor(props: IProps) {
     super(props);
-    this.state = {
-      templateValue: '',
-      templateFocused: false
-    };
   }
 
   public render() {
-    return this.questionTemplateTab();
+    return this.mcqTab();
   }
-
-  private questionTemplateTab = () => {
-    // tslint:disable-next-line:no-console
-    // console.dir(this.props.assessment)
-    const type = this.props.assessment!.questions[this.props.questionId].type;
-    const display = type === 'mcq' ? this.mcqTab() : this.programmingTab();
-
-    return display;
-  };
-
-  private programmingTab = () => {
-    const path = ['questions', this.props.questionId, 'answer'];
-
-    const handleTemplateChange = (newCode: string) => {
-      this.setState({
-        templateValue: newCode
-      });
-    };
-
-    const value = this.state.templateFocused
-      ? this.state.templateValue
-      : getValueFromPath(path, this.props.assessment);
-
-    const display = (
-      <div onClick={this.focusEditor(path)} onBlur={this.unFocusEditor(path)}>
-        <AceEditor
-          className="react-ace"
-          editorProps={{
-            $blockScrolling: Infinity
-          }}
-          fontSize={14}
-          highlightActiveLine={false}
-          mode="javascript"
-          onChange={handleTemplateChange}
-          theme="cobalt"
-          value={value}
-          width="100%"
-        />
-      </div>
-    );
-
-    return display;
-  };
-
-  private focusEditor = (path: Array<string | number>) => (e: any): void => {
-    if (!this.state.templateFocused) {
-      this.setState({
-        templateValue: getValueFromPath(path, this.props.assessment),
-        templateFocused: true
-      });
-    }
-  };
-
-  private unFocusEditor = (path: Array<string | number>) => (e: any): void => {
-    if (this.state.templateFocused) {
-      const value = getValueFromPath(path, this.props.assessment);
-      if (value !== this.state.templateValue) {
-        const assessmentVal = this.props.assessment;
-        assignToPath(path, this.state.templateValue, assessmentVal);
-        this.props.updateAssessment(assessmentVal);
-      }
-      this.setState({
-        templateValue: '',
-        templateFocused: false
-      });
-    }
-  };
 
   private mcqTab = () => {
     const questionId = this.props.questionId;
@@ -111,6 +34,7 @@ export class QuestionTemplateTab extends React.Component<IProps, IState> {
         {this.textareaContent(['questions', questionId, 'choices', i, 'hint'])}
       </div>
     ));
+    const deleteButton = controlButton('Delete Option', IconNames.REMOVE, this.delOption);
 
     return (
       <div className="MCQChooser row">
@@ -118,9 +42,13 @@ export class QuestionTemplateTab extends React.Component<IProps, IState> {
           <div className="row mcq-options-parent between-xs">
             {mcqButton}
             Solution:
-            {this.textareaContent(['questions', questionId, 'solution'], true, [0, 3])}
+            {this.textareaContent(['questions', questionId, 'solution'], true, [
+              0,
+              question.choices.length
+            ])}
+            <br />
             {controlButton('Add Option', IconNames.CONFIRM, this.addOption)}
-            {controlButton('Delete Option', IconNames.REMOVE, this.delOption)}
+            {question.choices.length > 0 ? deleteButton : undefined}
           </div>
         </Card>
       </div>
@@ -179,4 +107,4 @@ export class QuestionTemplateTab extends React.Component<IProps, IState> {
   };
 }
 
-export default QuestionTemplateTab;
+export default MCQQuestionTemplateTab;

--- a/src/components/incubator/editingWorkspaceSideContent/ProgrammingQuestionTemplateTab.tsx
+++ b/src/components/incubator/editingWorkspaceSideContent/ProgrammingQuestionTemplateTab.tsx
@@ -1,0 +1,146 @@
+import { Switch } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import * as React from 'react';
+import AceEditor from 'react-ace';
+
+import { IAssessment } from '../../assessment/assessmentShape';
+import { controlButton } from '../../commons';
+import { assignToPath, getValueFromPath } from './';
+
+interface IProps {
+  assessment: IAssessment;
+  editorValue: string | null;
+  questionId: number;
+  updateAssessment: (assessment: IAssessment) => void;
+  handleEditorValueChange: (val: string) => void;
+}
+
+interface IState {
+  templateValue: string;
+  templateFocused: boolean;
+  isSuggestedAnswer: boolean;
+}
+
+export class ProgrammingQuestionTemplateTab extends React.Component<IProps, IState> {
+  public constructor(props: IProps) {
+    super(props);
+    this.state = {
+      templateValue: '',
+      templateFocused: false,
+      isSuggestedAnswer: false
+    };
+  }
+
+  public render() {
+    return this.programmingTab();
+  }
+
+  private programmingTab = () => {
+    const qnPath = ['questions', this.props.questionId];
+    const templateSwitch = (
+      <Switch
+        checked={this.state.isSuggestedAnswer}
+        label="Edit suggested answers"
+        onChange={this.toggleTemplateMode}
+      />
+    );
+    const path = this.state.isSuggestedAnswer
+      ? qnPath.concat(['answer'])
+      : qnPath.concat(['solutionTemplate']);
+
+    const copyFromEditorButton = controlButton(
+      'Copy from Editor',
+      IconNames.IMPORT,
+      this.handleCopyFromEditor(path)
+    );
+
+    const copyToEditorButton = controlButton(
+      'Copy to Editor',
+      IconNames.EXPORT,
+      this.handleCopyToEditor(path)
+    );
+
+    const handleTemplateChange = (newCode: string) => {
+      this.setState({
+        templateValue: newCode
+      });
+    };
+
+    const value = this.state.templateFocused
+      ? this.state.templateValue
+      : getValueFromPath(path, this.props.assessment);
+
+    const editor = (
+      <div onClick={this.focusEditor(path)} onBlur={this.unFocusEditor(path)}>
+        <AceEditor
+          className="react-ace"
+          editorProps={{
+            $blockScrolling: Infinity
+          }}
+          fontSize={14}
+          highlightActiveLine={false}
+          mode="javascript"
+          onChange={handleTemplateChange}
+          theme="cobalt"
+          value={value}
+          width="100%"
+        />
+      </div>
+    );
+
+    return (
+      <div>
+        {templateSwitch}
+        {copyFromEditorButton}
+        {copyToEditorButton}
+        <br />
+        <br />
+        {editor}
+        }
+      </div>
+    );
+  };
+
+  private focusEditor = (path: Array<string | number>) => (e: any): void => {
+    if (!this.state.templateFocused) {
+      this.setState({
+        templateValue: getValueFromPath(path, this.props.assessment),
+        templateFocused: true
+      });
+    }
+  };
+
+  private unFocusEditor = (path: Array<string | number>) => (e: any): void => {
+    if (this.state.templateFocused) {
+      const value = getValueFromPath(path, this.props.assessment);
+      if (value !== this.state.templateValue) {
+        const assessmentVal = this.props.assessment;
+        assignToPath(path, this.state.templateValue, assessmentVal);
+        this.props.updateAssessment(assessmentVal);
+      }
+      this.setState({
+        templateValue: '',
+        templateFocused: false
+      });
+    }
+  };
+
+  private toggleTemplateMode = () => {
+    this.setState({
+      isSuggestedAnswer: !this.state.isSuggestedAnswer
+    });
+  };
+
+  private handleCopyFromEditor = (path: Array<string | number>) => (): void => {
+    const assessment = this.props.assessment;
+    assignToPath(path, this.props.editorValue, assessment);
+    this.props.updateAssessment(assessment);
+  };
+
+  private handleCopyToEditor = (path: Array<string | number>) => (): void => {
+    const value = getValueFromPath(path, this.props.assessment);
+    this.props.handleEditorValueChange(value);
+  };
+}
+
+export default ProgrammingQuestionTemplateTab;

--- a/src/components/incubator/editingWorkspaceSideContent/index.tsx
+++ b/src/components/incubator/editingWorkspaceSideContent/index.tsx
@@ -1,10 +1,18 @@
 import DeploymentTab from './DeploymentTab';
 import GradingTab from './GradingTab';
 import ManageQuestionTab from './ManageQuestionTab';
-import QuestionTemplateTab from './QuestionTemplateTab';
+import MCQQuestionTemplateTab from './MCQQuestionTemplateTab';
+import ProgrammingQuestionTemplateTab from './ProgrammingQuestionTemplateTab';
 import TextareaContentTab from './TextareaContent';
 
-export { DeploymentTab, GradingTab, ManageQuestionTab, QuestionTemplateTab, TextareaContentTab };
+export {
+  DeploymentTab,
+  GradingTab,
+  ManageQuestionTab,
+  MCQQuestionTemplateTab,
+  ProgrammingQuestionTemplateTab,
+  TextareaContentTab
+};
 
 export const getValueFromPath = (path: Array<string | number>, obj: any): any => {
   for (const next of path) {

--- a/src/components/workspace/ControlBar.tsx
+++ b/src/components/workspace/ControlBar.tsx
@@ -33,11 +33,13 @@ export type ControlBarProps = {
   hasUnsavedChanges?: boolean;
   isEditorAutorun?: boolean;
   isRunning: boolean;
+  editingMode?: string;
   onClickNext?(): any;
   onClickPrevious?(): any;
   onClickReturn?(): any;
   onClickSave?(): any;
   onClickReset?(): any;
+  toggleEditMode?(): void;
 };
 
 interface IChapter {
@@ -138,9 +140,10 @@ class ControlBar extends React.PureComponent<ControlBarProps, {}> {
     const stopAutorunButton = this.props.hasEditorAutorunButton
       ? controlButton('Autorun', IconNames.STOP, this.props.handleToggleEditorAutorun)
       : undefined;
-    const resetButton = this.props.hasSaveButton
-      ? controlButton('Reset', IconNames.REPEAT, this.props.onClickReset)
-      : undefined;
+    const resetButton =
+      this.props.onClickReset !== null
+        ? controlButton('Reset', IconNames.REPEAT, this.props.onClickReset)
+        : undefined;
     return (
       <div className="ControlBar_editor pt-button-group">
         {this.props.isEditorAutorun ? undefined : this.props.isRunning ? stopButton : runButton}
@@ -182,15 +185,30 @@ class ControlBar extends React.PureComponent<ControlBarProps, {}> {
   }
 
   private replControl() {
+    const toggleEditModeButton =
+      this.props.toggleEditMode !== null ? (
+        <Tooltip
+          content={
+            'Switch to ' +
+            (this.props.editingMode === 'question' ? 'global' : 'question specific') +
+            ' editing mode.'
+          }
+        >
+          {controlButton('Switch editing mode', IconNames.REFRESH, this.props.toggleEditMode)}
+        </Tooltip>
+      ) : (
+        undefined
+      );
     const evalButton = (
       <Tooltip content="...or press shift-enter in the REPL">
         {controlButton('Eval', IconNames.CODE, this.props.handleReplEval)}
       </Tooltip>
     );
     const clearButton = controlButton('Clear', IconNames.REMOVE, this.props.handleReplOutputClear);
+
     return (
       <div className="ControlBar_repl pt-button-group">
-        {this.props.isRunning ? null : evalButton} {clearButton}
+        {this.props.isRunning ? null : evalButton} {clearButton} {toggleEditModeButton}
       </div>
     );
   }

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -84,6 +84,7 @@ const makeAssessmentOverview = (
     maxXp: maxXpVal,
     openAt: rawOverview.startdate,
     title: rawOverview.title,
+    reading: task.READING !== null ? task.READING[0] : '',
     shortSummary: task.WEBSUMMARY ? task.WEBSUMMARY[0] : '',
     status: AssessmentStatuses.attempting,
     story: rawOverview.story,
@@ -208,8 +209,8 @@ const makeProgramming = (
 ): IProgrammingQuestion => {
   const result: IProgrammingQuestion = {
     ...question,
-    answer: problem.SNIPPET[0].TEMPLATE[0] as string,
-    solutionTemplate: problem.SNIPPET[0].SOLUTION[0] as string,
+    solutionTemplate: problem.SNIPPET[0].TEMPLATE[0] as string,
+    answer: problem.SNIPPET[0].SOLUTION[0] as string,
     type: 'programming'
   };
   if (problem.SNIPPET[0].GRADER) {
@@ -297,6 +298,10 @@ export const assessmentToXml = (
   };
   task.$ = rawOverview;
 
+  if (overview.reading && overview.reading !== '') {
+    task.READING = overview.reading;
+  }
+
   task.WEBSUMMARY = overview.shortSummary;
   task.TEXT = assessment.longSummary;
   task.PROBLEMS = { PROBLEM: [] };
@@ -336,13 +341,12 @@ export const assessmentToXml = (
     }
 
     if (question.type === 'programming') {
-      problem.SNIPPET.SOLUTION = question.solutionTemplate;
       if (question.graderTemplate) {
         /* tslint:disable:no-string-literal */
         problem.SNIPPET['GRADER'] = question.graderTemplate;
       }
       /* tslint:disable:no-string-literal */
-      problem.SNIPPET['TEMPLATE'] = question.answer;
+      problem.SNIPPET['TEMPLATE'] = question.solutionTemplate;
     }
 
     if (question.type === 'mcq') {


### PR DESCRIPTION
* Removed previous button on first question, added divider

* Yarn format

* Changeded help description

* fix import for firefox

* max width for globals

* symbols aligned

* increase abstraction

removed numberRange from textArea
Reduced save frequency of solutionTemplate

* manage questions give warning

* UI change for deployment tab

* fixed maxGrade and maxXP calculation

* added local/global switch

* adjust mcq options

* split question template tab

added suggested answer editing

* swap answer and solutionTemplate

internal change

* add reading

* add grading deployment