### PR TITLE
Mission editing slang (#505)

### DIFF
--- a/src/components/assessment/assessmentShape.ts
+++ b/src/components/assessment/assessmentShape.ts
@@ -10,6 +10,7 @@ export interface IAssessmentOverview {
   category: AssessmentCategory;
   closeAt: string;
   coverImage: string;
+  fileName?: string;
   grade: number;
   id: number;
   maxGrade: number;

--- a/src/components/incubator/EditingOverviewCard.tsx
+++ b/src/components/incubator/EditingOverviewCard.tsx
@@ -1,5 +1,17 @@
-import { Button, Card, Elevation, Icon, IconName, Intent, Text } from '@blueprintjs/core';
+import {
+  Button,
+  Card,
+  Classes,
+  Dialog,
+  Elevation,
+  Icon,
+  IconName,
+  Intent,
+  MenuItem,
+  Text
+} from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
+import { ItemRenderer, Select } from '@blueprintjs/select';
 import * as React from 'react';
 import { NavLink } from 'react-router-dom';
 import Textarea from 'react-textarea-autosize';
@@ -9,7 +21,11 @@ import { getPrettyDate } from '../../utils/dateHelpers';
 import { assessmentCategoryLink } from '../../utils/paramParseHelpers';
 import { exportXml } from '../../utils/xmlParser';
 
-import { IAssessmentOverview } from '../assessment/assessmentShape';
+import {
+  AssessmentCategories,
+  AssessmentCategory,
+  IAssessmentOverview
+} from '../assessment/assessmentShape';
 import { controlButton } from '../commons';
 import Markdown from '../commons/Markdown';
 
@@ -24,6 +40,7 @@ type Props = {
 interface IState {
   editingOverviewField: string;
   fieldValue: any;
+  showOptionsOverlay: boolean;
 }
 
 export class EditingOverviewCard extends React.Component<Props, IState> {
@@ -31,12 +48,18 @@ export class EditingOverviewCard extends React.Component<Props, IState> {
     super(props);
     this.state = {
       editingOverviewField: '',
-      fieldValue: ''
+      fieldValue: '',
+      showOptionsOverlay: false
     };
   }
 
   public render() {
-    return <div>{this.makeEditingOverviewCard(this.props.overview)}</div>;
+    return (
+      <div>
+        {this.optionsOverlay()}
+        {this.makeEditingOverviewCard(this.props.overview)}
+      </div>
+    );
   }
 
   private saveEditOverview = (field: keyof IAssessmentOverview) => (e: any) => {
@@ -67,7 +90,13 @@ export class EditingOverviewCard extends React.Component<Props, IState> {
     }
   };
 
-  private handleExportXml = () => (e: any) => {
+  private toggleOptionsOverlay = () => {
+    this.setState({
+      showOptionsOverlay: !this.state.showOptionsOverlay
+    });
+  };
+
+  private handleExportXml = (e: any) => {
     exportXml();
   };
 
@@ -127,6 +156,7 @@ export class EditingOverviewCard extends React.Component<Props, IState> {
                   : `${getPrettyDate(overview.closeAt)}`}
               </div>
             </Text>
+            {this.makeOptionsButton()}
             {makeOverviewCardButton(overview, this.props.listingPath)}
           </div>
         </div>
@@ -149,22 +179,66 @@ export class EditingOverviewCard extends React.Component<Props, IState> {
 
   private makeExportButton = (overview: IAssessmentOverview) => (
     <Button
-      // disabled={overview.status !== AssessmentStatuses.attempted}
       icon={IconNames.EXPORT}
       intent={Intent.DANGER}
       minimal={true}
       // intentional: each menu renders own version of onClick
       // tslint:disable-next-line:jsx-no-lambda
-      onClick={this.handleExportXml()}
+      onClick={this.handleExportXml}
     >
       Export XML
     </Button>
+  );
+
+  private makeOptionsButton = () => (
+    <Button icon={IconNames.WRENCH} minimal={true} onClick={this.toggleOptionsOverlay}>
+      Other Options
+    </Button>
+  );
+
+  private saveCategory = (i: AssessmentCategory, e: any) => {
+    const overview = {
+      ...this.props.overview,
+      category: i
+    };
+    localStorage.setItem('MissionEditingOverviewSA', JSON.stringify(overview));
+    this.props.updateEditingOverview(overview);
+  };
+
+  private optionsOverlay = () => (
+    <Dialog
+      canOutsideClickClose={false}
+      className="assessment-reset"
+      icon={IconNames.WRENCH}
+      isCloseButtonShown={true}
+      isOpen={this.state.showOptionsOverlay}
+      onClose={this.toggleOptionsOverlay}
+      title="Other options"
+    >
+      <div className={Classes.DIALOG_BODY}>
+        <h3>Category</h3>
+        {categorySelect(this.props.overview.category, this.saveCategory)}
+        <h3>Story</h3>
+        <div onClick={this.toggleEditField('story')}>
+          {this.state.editingOverviewField === 'story'
+            ? this.makeEditingOverviewTextarea('story')
+            : createPlaceholder(this.props.overview.story || '')}
+        </div>
+        <br />
+        <h3>Filename</h3>
+        <div onClick={this.toggleEditField('fileName')}>
+          {this.state.editingOverviewField === 'fileName'
+            ? this.makeEditingOverviewTextarea('fileName')
+            : createPlaceholder(this.props.overview.fileName || '')}
+        </div>
+      </div>
+    </Dialog>
   );
 }
 
 const createPlaceholder = (str: string): string => {
   if (str.match('^(\n| )*$')) {
-    return 'Enter Value Here.';
+    return 'Enter Value Here (If Applicable)';
   } else {
     return str;
   }
@@ -180,3 +254,32 @@ const makeOverviewCardButton = (overview: IAssessmentOverview, listingPath: stri
     </NavLink>
   );
 };
+
+const assessmentCategoriesArr = [
+  AssessmentCategories.Mission,
+  AssessmentCategories.Path,
+  AssessmentCategories.Sidequest,
+  AssessmentCategories.Contest
+];
+
+const categorySelect = (
+  category: AssessmentCategory,
+  handleSelect = (i: AssessmentCategory, e: React.ChangeEvent<HTMLSelectElement>) => {}
+) => (
+  <CategorySelectComponent
+    className="pt-minimal"
+    items={assessmentCategoriesArr}
+    onItemSelect={handleSelect}
+    itemRenderer={categoryRenderer}
+    filterable={false}
+  >
+    <Button className="pt-minimal" text={category} rightIcon="double-caret-vertical" />
+  </CategorySelectComponent>
+);
+
+const CategorySelectComponent = Select.ofType<AssessmentCategory>();
+
+const categoryRenderer: ItemRenderer<AssessmentCategory> = (
+  category,
+  { handleClick, modifiers, query }
+) => <MenuItem active={false} key={category} onClick={handleClick} text={category} />;

--- a/src/components/incubator/ImportFromFileComponent.tsx
+++ b/src/components/incubator/ImportFromFileComponent.tsx
@@ -51,14 +51,15 @@ export class ImportFromFileComponent extends React.Component<Props, State> {
     );
   }
 
-  private handleFileRead = (e: any) => {
+  private handleFileRead = (file: any) => (e: any) => {
     const content = this.fileReader.result;
     if (content) {
       parseString(content, (err: any, result: any) => {
         // tslint:disable-next-line:no-console
-        // console.dir(result);
+        console.dir(file);
         try {
           const entireAssessment: [IAssessmentOverview, IAssessment] = makeEntireAssessment(result);
+          entireAssessment[0].fileName = file.name.slice(0, -4);
           localStorage.setItem('MissionEditingOverviewSA', JSON.stringify(entireAssessment[0]));
           this.props.updateEditingOverview(entireAssessment[0]);
 
@@ -82,7 +83,7 @@ export class ImportFromFileComponent extends React.Component<Props, State> {
     const files = e.target.files;
     if (e.target.files) {
       this.fileReader = new FileReader();
-      this.fileReader.onloadend = this.handleFileRead;
+      this.fileReader.onloadend = this.handleFileRead(files[0]);
       this.fileReader.readAsText(files[0]);
     }
   };
@@ -90,7 +91,6 @@ export class ImportFromFileComponent extends React.Component<Props, State> {
   private makeMission = () => {
     localStorage.setItem('MissionEditingOverviewSA', JSON.stringify(overviewTemplate()));
     this.props.updateEditingOverview(overviewTemplate());
-
     localStorage.setItem('MissionEditingAssessmentSA', JSON.stringify(assessmentTemplate()));
     this.props.newAssessment(assessmentTemplate());
   };

--- a/src/components/incubator/editingWorkspaceSideContent/DeploymentTab.tsx
+++ b/src/components/incubator/editingWorkspaceSideContent/DeploymentTab.tsx
@@ -264,6 +264,10 @@ const removeSpaces = (str: string) => {
   return str.replace(/\s+/g, '');
 };
 
+const altEval = (str: string): any => {
+  return Function('"use strict";return (' + str + ')')();
+};
+
 function styliseChapter(chap: number) {
   return `Source \xa7${chap}`;
 }
@@ -288,10 +292,6 @@ const chapterSelect = (
     />
   </ChapterSelectComponent>
 );
-
-const altEval = (str: string): any => {
-  return Function('"use strict";return (' + str + ')')();
-};
 
 const ChapterSelectComponent = Select.ofType<IChapter>();
 

--- a/src/components/incubator/editingWorkspaceSideContent/ManageQuestionTab.tsx
+++ b/src/components/incubator/editingWorkspaceSideContent/ManageQuestionTab.tsx
@@ -1,4 +1,4 @@
-import { ButtonGroup, Classes, Dialog, Intent } from '@blueprintjs/core';
+import { Button, ButtonGroup, Classes, Dialog, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as React from 'react';
 
@@ -33,40 +33,59 @@ export class ManageQuestionTab extends React.Component<IProps, IState> {
     return (
       <div>
         {this.confirmSaveOverlay()}
-        {this.manageQuestionTab()}
+        {this.props.assessment.questions.map((q, index) => (
+          <div key={index}>
+            Question {index + 1}
+            <br />
+            <Button className="mcq-option col-xs-12" minimal={true}>
+              <Markdown
+                content={q.content.length > 200 ? q.content.substring(0, 300) + '...' : q.content}
+              />
+            </Button>
+            {this.manageQuestionTab(index)}
+            <br />
+            <br />
+          </div>
+        ))}
       </div>
     );
   }
 
-  private manageQuestionTab = () => {
-    const index = this.props.questionId;
+  private manageQuestionTab = (index: number) => {
     return (
       <div>
         {controlButton(
-          'Clone Current Question',
+          `Clone`,
           IconNames.DOCUMENT,
           this.confirmSave(
-            this.makeQuestion(() =>
-              deepCopy(this.props.assessment.questions[this.props.questionId])
-            )
+            this.makeQuestion(() => deepCopy(this.props.assessment.questions[index]), index)
           )
+        )}
+        {controlButton(`Delete`, IconNames.REMOVE, this.confirmSave(this.deleteQuestion(index)))}
+        {controlButton(
+          `Shift Up`,
+          IconNames.CARET_UP,
+          this.confirmSave(this.shiftQuestion(-1, index)),
+          {},
+          index === 0
+        )}
+        {controlButton(
+          `Shift Down`,
+          IconNames.CARET_DOWN,
+          this.confirmSave(this.shiftQuestion(1, index)),
+          {},
+          index >= this.props.assessment.questions.length - 1
         )}
         <br />
         {controlButton(
           'Insert Programming Question',
           IconNames.FONT,
-          this.confirmSave(this.makeQuestion(programmingTemplate))
+          this.confirmSave(this.makeQuestion(programmingTemplate, index))
         )}
         {controlButton(
           'Insert MCQ Question',
           IconNames.CONFIRM,
-          this.confirmSave(this.makeQuestion(mcqTemplate))
-        )}
-        <br />
-        {controlButton(
-          'Delete Current Question',
-          IconNames.REMOVE,
-          this.confirmSave(this.deleteQuestion)
+          this.confirmSave(this.makeQuestion(mcqTemplate, index))
         )}
         <br />
         {index > 0
@@ -87,9 +106,8 @@ export class ManageQuestionTab extends React.Component<IProps, IState> {
     );
   };
 
-  private shiftQuestion = (dir: number) => () => {
+  private shiftQuestion = (dir: number, index: number) => () => {
     const assessment = this.props.assessment;
-    const index = this.props.questionId;
     const newIndex = index + dir;
     if (newIndex >= 0 && newIndex < assessment.questions.length) {
       const question = assessment.questions[index];
@@ -102,9 +120,9 @@ export class ManageQuestionTab extends React.Component<IProps, IState> {
     }
   };
 
-  private makeQuestion = (template: () => any) => () => {
+  private makeQuestion = (template: () => any, index: number) => () => {
     const assessment = this.props.assessment;
-    const index = this.props.questionId + 1;
+    index = index + 1;
     const questions = assessment.questions;
     questions.splice(index, 0, template());
     assessment.questions = questions;
@@ -112,10 +130,9 @@ export class ManageQuestionTab extends React.Component<IProps, IState> {
     history.push('/incubator/-1/' + index.toString());
   };
 
-  private deleteQuestion = () => {
+  private deleteQuestion = (index: number) => () => {
     const assessment = this.props.assessment;
     let questions = assessment.questions;
-    const index = this.props.questionId;
     if (questions.length > 1) {
       questions = questions.slice(0, index).concat(questions.slice(index + 1));
     }

--- a/src/components/workspace/ControlBar.tsx
+++ b/src/components/workspace/ControlBar.tsx
@@ -26,11 +26,13 @@ export type ControlBarProps = {
   handleReplEval: () => void;
   handleReplOutputClear: () => void;
   handleToggleEditorAutorun?: () => void;
+  handleToggleEditorPersist?: () => void;
   hasChapterSelect: boolean;
   hasEditorAutorunButton: boolean;
   hasSaveButton: boolean;
   hasShareButton: boolean;
   hasUnsavedChanges?: boolean;
+  isEditorPersist?: boolean;
   isEditorAutorun?: boolean;
   isRunning: boolean;
   editingMode?: string;
@@ -144,6 +146,14 @@ class ControlBar extends React.PureComponent<ControlBarProps, {}> {
       this.props.onClickReset !== null
         ? controlButton('Reset', IconNames.REPEAT, this.props.onClickReset)
         : undefined;
+    const editorPersistSwitch =
+      this.props.handleToggleEditorPersist !== null
+        ? controlButton(
+            'Editor Persistence ' + (this.props.isEditorPersist ? 'Enabled' : 'Disabled'),
+            this.props.isEditorPersist ? IconNames.TICK : IconNames.CROSS,
+            this.props.handleToggleEditorPersist
+          )
+        : undefined;
     return (
       <div className="ControlBar_editor pt-button-group">
         {this.props.isEditorAutorun ? undefined : this.props.isRunning ? stopButton : runButton}
@@ -151,6 +161,7 @@ class ControlBar extends React.PureComponent<ControlBarProps, {}> {
         {shareButton} {chapterSelectButton} {externalSelectButton}
         {this.props.isEditorAutorun ? stopAutorunButton : startAutorunButton}
         {resetButton}
+        {editorPersistSwitch}
       </div>
     );
   }

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -30,11 +30,7 @@ const capitalizeFirstLetter = (str: string) => {
 export const retrieveLocalAssessment = (): IAssessment | null => {
   const assessment = localStorage.getItem('MissionEditingAssessmentSA');
   if (assessment) {
-    try {
-      return JSON.parse(assessment);
-    } catch (err) {
-      return null;
-    }
+    return JSON.parse(assessment);
   } else {
     return null;
   }
@@ -43,11 +39,7 @@ export const retrieveLocalAssessment = (): IAssessment | null => {
 export const retrieveLocalAssessmentOverview = (): IAssessmentOverview | null => {
   const assessment = localStorage.getItem('MissionEditingOverviewSA');
   if (assessment) {
-    try {
-      return JSON.parse(assessment);
-    } catch (err) {
-      return null;
-    }
+    return JSON.parse(assessment);
   } else {
     return null;
   }
@@ -84,7 +76,7 @@ const makeAssessmentOverview = (
     maxXp: maxXpVal,
     openAt: rawOverview.startdate,
     title: rawOverview.title,
-    reading: task.READING !== null ? task.READING[0] : '',
+    reading: task.READING ? task.READING[0] : '',
     shortSummary: task.WEBSUMMARY ? task.WEBSUMMARY[0] : '',
     status: AssessmentStatuses.attempting,
     story: rawOverview.story,
@@ -225,7 +217,7 @@ export const exportXml = () => {
   if (assessmentStr && overviewStr) {
     const assessment: IAssessment = JSON.parse(assessmentStr);
     const overview: IAssessmentOverview = JSON.parse(overviewStr);
-    const title = assessment.title;
+    const filename = overview.fileName || overview.title;
     const builder = new Builder();
     const xmlTask: IXmlParseStrTask = assessmentToXml(assessment, overview);
     const xml = {
@@ -238,7 +230,7 @@ export const exportXml = () => {
     };
     let xmlStr = builder.buildObject(xml);
     xmlStr = xmlStr.replace(/(&#xD;)+/g, '');
-    download(title + '.xml', xmlStr);
+    download(filename + '.xml', xmlStr);
   }
 };
 


### PR DESCRIPTION
* Removed previous button on first question, added divider

* Yarn format

* Changeded help description

* fix import for firefox

* max width for globals

* symbols aligned

* increase abstraction

removed numberRange from textArea
Reduced save frequency of solutionTemplate

* manage questions give warning

* UI change for deployment tab

* fixed maxGrade and maxXP calculation

* added local/global switch

* adjust mcq options

* split question template tab

added suggested answer editing

* swap answer and solutionTemplate

internal change

* add reading

* add grading deployment

* clone question shift question added

* fixed symbol formating

* changed manage questions ui

* yarn format

* added more overview options

* add editing persist

* Update ManageQuestionTab.tsx